### PR TITLE
fix: not active label when value is equel to 0

### DIFF
--- a/packages/react-redux-form-materialize/package.json
+++ b/packages/react-redux-form-materialize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-form-materialize",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Basic input controls for react-redux-form leveraged by Materialize Material UI framework",
   "main": "lib/index.js",
   "repository": "https://github.com/OptimalSpin/materialize-controls",

--- a/packages/react-redux-form-materialize/src/helpers/inputHelpers.js
+++ b/packages/react-redux-form-materialize/src/helpers/inputHelpers.js
@@ -28,5 +28,5 @@ export const getIconColor = ({
 };
 
 export const getLabelClassName = ({ innerState, value }, errors) => (cn({
-  active: innerState.focus || innerState.value || errors.length || value,
+  active: innerState.focus || innerState.value || errors.length || value || value === 0,
 }));


### PR DESCRIPTION
![screenshot from 2018-02-09 12-21-20](https://user-images.githubusercontent.com/20453923/36013581-9ce3f686-0d97-11e8-85c5-4193f7a01efb.png)
When we set value is equel to `0` `getLabelClassName` doesn't set `active` class name.